### PR TITLE
Make template dynamic based on the value of the key

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The design is inspired from the debconf tool, used on debian-based systems, but 
 
 It is a simple collection of bash scripts used to iteratively launch the `configure`, `preinstall`, and `postinstall` steps of wizard **addons**.
 
-Addons do what's needed to configure and install specific system depencies for the package that is currently being configured. For instance, a GitLab package may use an installer that depends on an `apache2` and `mysql` wizard addons.
+Addons do what's needed to configure and install specific system dependencies for the package that is currently being configured. For instance, a GitLab package may use an installer that depends on an `apache2` and `mysql` wizard addons.
 
 The installer provides shell functions that abstract the setting/retrieval of configuration entries, and also displays interactive questions to the user.
 
@@ -133,6 +133,8 @@ wiz_meta "mysql/db_host" "default" # => 127.0.0.1
 wiz_meta "mysql/db_host" "type" # => string
 ```
 
+It's possible to override a template based on the value of the key. For instance, if the user has already set the value `skip` for `mysql/autoinstall`, then the template `mysql/autoinstall=skip` will be looked up first, and then `mysql/autoinstall` will be looked up. This allows for more dynamic templates based on the previous user's input.
+
 ### `wiz_put`
 
 Adds a question to the buffer of questions to be asked.
@@ -201,3 +203,14 @@ wiz_urlencode "mysql://user:pass@host:port/dbname?hello=world"
 * https://github.com/pkgr/addon-smtp - Addon for configuring SMTP settings or sendmail.
 * https://github.com/pkgr/addon-memcached - Addon for setting up a memcached server.
 * https://github.com/pkgr/addon-apache2 - Addon for setting up an Apache2 server, including SSL.
+
+## Testing
+
+Tests are located in the `test` folder. To run them:
+
+```bash
+test/wiz_get.sh
+test/wiz_meta.sh
+```
+
+Set `DEBUG=1` to have a more verbose output.

--- a/test/assert.sh
+++ b/test/assert.sh
@@ -108,7 +108,7 @@ assert() {
     result="$(sed -e :a -e '$!N;s/\n/\\n/;ta' <<< "$result")"
     [[ -z "$result" ]] && result="nothing" || result="\"$result\""
     [[ -z "$2" ]] && expected="nothing" || expected="\"$2\""
-    _assert_fail "expected $expected${_indent}got $result" "$1" "$3"
+    _assert_fail "expected $expected${_indent}     got $result" "$1" "$3"
 }
 
 assert_raises() {

--- a/test/fixtures/templates
+++ b/test/fixtures/templates
@@ -1,9 +1,21 @@
 Template: mysql/autoinstall
 Type: select
-Choices: skip, use an existing database, create a new database 
+Choices: skip, use an existing database, create a new database
 Translations: Skip this wizard altogether, Use an existing MySQL database, Create a new database (requires MySQL superuser password)
 Default: skip
 Description: Do you want to use this wizard to help setup your MySQL database?
+ If you want, we can automatically create the MySQL database required by _APP_NAME_.
+ .
+ If you choose NOT to use this wizard, you will have to manually setup all the things related to the database.
+
+Template: mysql/autoinstall=use an existing database
+Type: select
+Choices: skip, use an existing database, create a new database
+Translations: Skip this wizard altogether, Keep existing MySQL database, Create a new database (requires MySQL superuser password)
+Default: use an existing database
+Description: Do you want to keep your existing database?
+ You previously chose to use your existing MySQL database.
+ .
  If you want, we can automatically create the MySQL database required by _APP_NAME_.
  .
  If you choose NOT to use this wizard, you will have to manually setup all the things related to the database.
@@ -82,4 +94,3 @@ Template: mysql/ssl_cert
 Type: string
 Default: /etc/ssl/certs/example.com.crt
 Description: Path to the SSL certificate to use:
-

--- a/test/wiz_meta.sh
+++ b/test/wiz_meta.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 DIR=$(dirname "$0")
+export DATABASE=$(mktemp)
 
 . ${DIR}/assert.sh
 . $(dirname "$DIR")/wizard
@@ -32,6 +33,15 @@ test_choices() {
 assert "test_type" "select"
 assert "test_title" "Do you want to use this wizard to help setup your MySQL database?"
 assert "test_default" "skip"
-assert "test_description" "If you want, we can automatically create the MySQL database required by _APP_NAME_. If you choose NOT to use this wizard, you will have to manually setup all the things related to the database."
-assert "test_choices" '"skip" "Skip this wizard altogether" "use an existing database" "Use an existing MySQL database" "create a new database " "Create a new database (requires MySQL superuser password)"' 
+assert "test_description" "If you want, we can automatically create the MySQL database required by _APP_NAME_.\\\n\\\nIf you choose NOT to use this wizard, you will have to manually setup all the things related to the database."
+assert "test_choices" '"skip" "Skip this wizard altogether" "use an existing database" "Use an existing MySQL database" "create a new database" "Create a new database (requires MySQL superuser password)"'
+
+# template can be different depending on the current value
+wiz_set "mysql/autoinstall" "use an existing database"
+assert "test_type" "select"
+assert "test_title" "Do you want to keep your existing database?"
+assert "test_default" "use an existing database"
+assert "test_description" "You previously chose to use your existing MySQL database.\\\n\\\nIf you want, we can automatically create the MySQL database required by _APP_NAME_.\\\n\\\nIf you choose NOT to use this wizard, you will have to manually setup all the things related to the database."
+assert "test_choices" '"skip" "Skip this wizard altogether" "use an existing database" "Keep existing MySQL database" "create a new database" "Create a new database (requires MySQL superuser password)"'
+
 assert_end "wiz_meta"

--- a/wizard
+++ b/wizard
@@ -185,7 +185,7 @@ wiz_template() {
 	echo "${CURRENT_ADDON}/templates"
 }
 
-# Fetch a property from a quesion from the "templates" file.
+# Fetch a property from a question from the "templates" file.
 # Outputs the result on STDOUT.
 # e.g.
 # 	wiz_meta("mysql/db_host", "description")
@@ -195,17 +195,28 @@ wiz_meta() {
 	wiz_debug "wiz_meta key=$key property=${attribute}"
 	IFS='/' read -a array <<< "$key"
 	local addon="${array[0]}"
+	local value=$(wiz_get "$key")
 	local tmpdir=$(mktemp -d)
 	local addon_templates=$(wiz_template "${addon}")
 
 	csplit -zs -f ${tmpdir}/item "$addon_templates" /^Template:/ {*}
 	local template=""
-	for file in ${tmpdir}/item* ; do
-		if grep -q "Template: ${key}" ${file} ; then
-			template="$file"
-			break
-		fi
-	done
+	if [ -n "$value" ] ; then
+		for file in ${tmpdir}/item* ; do
+			if grep -q "Template: ${key}=${value}" ${file} ; then
+				template="$file"
+				break
+			fi
+		done
+	fi
+	if [ -z "$template" ] ; then
+		for file in ${tmpdir}/item* ; do
+			if grep -q "Template: ${key}" ${file} ; then
+				template="$file"
+				break
+			fi
+		done
+	fi
 
 	if [ -z "$template" ] ; then exit 1 ; fi
 
@@ -220,7 +231,7 @@ wiz_meta() {
 			sed -n -r 's|^Default: (.+)$|\1|p' "$template"
 			;;
 		"description")
-			grep -e "^\s" "$template" | sed -r "s|^ \.\s*$|%NEWLINE%|g" | xargs echo | sed -r "s| ?%NEWLINE% |\\\n|g"
+			grep -e "^\s" "$template" | sed -r "s|^ \.\s*$|%NEWLINE%|g" | xargs echo | sed -r "s| ?%NEWLINE% |\\\n\\\n|g"
 			;;
 		"choices")
 			IFS=',' read -a choices <<< "$(sed -n -r 's|^Choices: (.+)$|\1|p' "$template" | sed -n -r 's|, ?|,|pg')"


### PR DESCRIPTION
It's possible to define additional versions of a template based on the current value of the key. This allows for more dynamic templates based on the previous user's input. For instance it can be used to indicate that a server would be uninstalled if "skip" is chosen during a reconfiguration.

Also:
- Change assert output to make diff easier to reader
- Keep paragraphs in the description: separate them with 2 newlines instead of only 1.